### PR TITLE
add option to add numbers (plus space)

### DIFF
--- a/src/builtin_pb/sentencepiece_model.pb.h
+++ b/src/builtin_pb/sentencepiece_model.pb.h
@@ -31,7 +31,7 @@
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
 #include <google/protobuf/generated_enum_util.h>
 // @@protoc_insertion_point(includes)
-#define PROTOBUF_INTERNAL_EXPORT_protobuf_sentencepiece_5fmodel_2eproto 
+#define PROTOBUF_INTERNAL_EXPORT_protobuf_sentencepiece_5fmodel_2eproto
 
 namespace protobuf_sentencepiece_5fmodel_2eproto {
 // Internal implementation detail -- do not use these members.
@@ -585,6 +585,12 @@ class TrainerSpec : public ::google::protobuf::MessageLite /* @@protoc_insertion
   bool add_punctuation_cjk() const;
   void set_add_punctuation_cjk(bool value);
 
+  // optional bool add_punctuation_cjk [default = false];
+  bool has_add_numbers() const;
+  void clear_add_numbers();
+  bool add_numbers() const;
+  void set_add_numbers(bool value);
+
   GOOGLE_PROTOBUF_EXTENSION_ACCESSORS(TrainerSpec)
   // @@protoc_insertion_point(class_scope:sentencepiece.TrainerSpec)
  private:
@@ -702,6 +708,7 @@ class TrainerSpec : public ::google::protobuf::MessageLite /* @@protoc_insertion
   bool split_by_unicode_script_;
   bool add_punctuation_;
   bool add_punctuation_cjk_;
+  bool add_numbers_;
   bool split_by_number_;
   bool split_by_whitespace_;
   bool hard_vocab_limit_;
@@ -2143,6 +2150,15 @@ inline bool TrainerSpec::add_punctuation_cjk() const {
 }
 inline void TrainerSpec::set_add_punctuation_cjk(bool value) {
   add_punctuation_cjk_ = value;
+  // @@protoc_insertion_point(field_set:sentencepiece.TrainerSpec.add_punctuation_cjk)
+}
+
+inline bool TrainerSpec::add_numbers() const {
+  // @@protoc_insertion_point(field_get:sentencepiece.TrainerSpec.add_punctuation_cjk)
+  return add_numbers_;
+}
+inline void TrainerSpec::set_add_numbers(bool value) {
+  add_numbers_ = value;
   // @@protoc_insertion_point(field_set:sentencepiece.TrainerSpec.add_punctuation_cjk)
 }
 

--- a/src/spm_train_main.cc
+++ b/src/spm_train_main.cc
@@ -110,6 +110,9 @@ DEFINE_bool(add_punctuation,
 DEFINE_bool(add_punctuation_cjk,
             false,
             "Add CJK punctuation symbols as symbols");
+DEFINE_bool(add_numbers,
+            false,
+            "Add numbers as symbols");
 
 void add_custom(std::vector<std::string> &list,
                      sentencepiece::TrainerSpec &spec) {
@@ -175,6 +178,7 @@ int main(int argc, char *argv[]) {
   SetTrainerSpecFromFlag(unk_surface);
   SetTrainerSpecFromFlag(add_punctuation);
   SetTrainerSpecFromFlag(add_punctuation_cjk);
+  SetTrainerSpecFromFlag(add_numbers);
   SetRepeatedTrainerSpecFromFlag(input);
   SetRepeatedTrainerSpecFromFlag(accept_language);
   SetRepeatedTrainerSpecFromFlag(control_symbols);
@@ -188,6 +192,11 @@ int main(int argc, char *argv[]) {
   if(trainer_spec.add_punctuation_cjk()) {
     std::vector<std::string> punctuation_cjk = {"…","‧","、","。","「","」","『","』","【","】","〜","゛","゜","・","﹁","﹂","！","＂","＃","％","＆","＇","（","）","＊","＋","，","－","．","／","：","；","＜","＝","＞","？","＠","［","＼","］","＾","＿","｀","｛","｜","｝","～","｟","｠","￢","￣","￤","ー"};
     add_custom(punctuation_cjk, trainer_spec);
+  }
+
+  if(trainer_spec.add_numbers()) {
+    std::vector<std::string> numbers = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+    add_custom(numbers, trainer_spec);
   }
 
   normalizer_spec.set_name(FLAGS_normalization_rule_name);


### PR DESCRIPTION
add `--add_numbers` flag:

```
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 0
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 0▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 1
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 1▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 2
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 2▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 3
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 3▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 4
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 4▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 5
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 5▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 6
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 6▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 7
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 7▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 8
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 8▁
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 9
trainer_interface.cc(330) LOG(INFO) Adding meta_piece: 9▁
```